### PR TITLE
release v2.0.4, removed unintended methods from public interface; add…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Work with Posix paths in Windows, recognized mount points in `/etc/fstab`.
 
 To use `unifile` in an `SBT` project, add this dependency to `build.sbt`
 ```sbt
-  "org.vastblue" % "unifile" % "0.2.2"
+  "org.vastblue" % "unifile" % "0.2.4"
 ```
 For `scala` or `scala-cli` scripts, see examples below.
 
@@ -67,7 +67,7 @@ This example might surprise developers working in a `Windows` posix shell, since
 #!/ usr / bin / env -S scala -cli shebang
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile::0.2.2"
+//> using lib "org.vastblue::unifile::0.2.4"
 
 import vastblue.unifile.Paths
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ javacOptions ++= Seq("-source", "11", "-target", "11")
 
 //ThisBuild / envFileName   := "dev.env" // sbt-dotenv plugin gets build environment here
 ThisBuild / scalaVersion  := scalaVer
-ThisBuild / version       := "0.2.3"
+ThisBuild / version       := "0.2.4"
 ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / organization         := "org.vastblue"

--- a/jsrc/bashPath.sc
+++ b/jsrc/bashPath.sc
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 
 import vastblue.unifile.*
 

--- a/jsrc/bashPathCli.sc
+++ b/jsrc/bashPathCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 
 import vastblue.unifile.*
 

--- a/jsrc/find.sc
+++ b/jsrc/find.sc
@@ -4,7 +4,7 @@ package vastblue.demo
 // hash bang line error on OSX/Darwin due to non-gnu /usr/bin/env
 // portable way to set classpath:
 // export SCALA_OPTS="@/Users/username/.scala3cp -save"
-// .scala3cp contains '-cp <path-to-unifile.jar>'
+// .scala3cp contains '-cp <path-to-thislib.jar>'
 
 import vastblue.unifile.*
 
@@ -18,7 +18,7 @@ object Find {
         for (f <- walkTree(dir.toFile, maxdepth = parms.maxdepth)) {
           val p = f.toPath
           if (parms.matches(p)) {
-            printf("%s\n", p.relpath.posixpath)
+            printf("%s\n", p.relpath.stdpath)
           }
         }
       }
@@ -51,7 +51,7 @@ object Find {
   }
 
   /**
-   * prepArgs returns `argv`, equivalent to C language main arguments vector.
+   * prepArgv returns `argv`, equivalent to C language main arguments vector.
    * jvm main#args and `argv.tail` identical if no `glob` args are passed.
    * `argv` always delivers unexpanded glob arguments, unlike main#args.
    */

--- a/jsrc/fstabCli.sc
+++ b/jsrc/fstabCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 
 import vastblue.unifile.*
 

--- a/jsrc/palletRef.sc
+++ b/jsrc/palletRef.sc
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 
 import vastblue.unifile.*
 

--- a/jsrc/palletRefCli.sc
+++ b/jsrc/palletRefCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 
 import vastblue.unifile.*
 

--- a/jsrc/showMountMap.sc
+++ b/jsrc/showMountMap.sc
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 import vastblue.unifile.*
-import vastblue.MountMapper.*
+import vastblue.file.MountMapper.*
 
 object ShowMountMap {
   def main(args: Array[String]): Unit = {

--- a/jsrc/unameGreeting.sc
+++ b/jsrc/unameGreeting.sc
@@ -1,7 +1,7 @@
 //#!/usr/bin/env -S scala
 package vastblue.demo
 
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 import vastblue.unifile.*
 
 object UnameGreeting {

--- a/jsrc/unameGreetingCli.sc
+++ b/jsrc/unameGreetingCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 
 import vastblue.unifile.*
 

--- a/src/main/scala/vastblue/MainArgs.scala
+++ b/src/main/scala/vastblue/MainArgs.scala
@@ -93,15 +93,17 @@ object MainArgs {
     val e: StackTraceElement = scriptProp(new Exception)
     val sprop = e.filePath
     val sjc: Array[String] = sunJavaCommand.split(" ")
-    val argz: Array[String] = {
+    var argz: Array[String] = {
       val list = sjc.dropWhile { (s: String) =>
         !s.endsWith(sprop) && !validScriptOrClassName(s)
       }
-      Array.ofDim[String](list.size+1)
+      (sprop :: list.toList).toArray
     }
-
+    require(argz.nonEmpty)
     if (sprop.nonEmpty) {
       argz(0) = sprop
+    } else {
+      argz(0) = "unknown-main"
     }
     argz.toIndexedSeq
   }

--- a/src/main/scala/vastblue/Platform.scala
+++ b/src/main/scala/vastblue/Platform.scala
@@ -15,8 +15,9 @@ import scala.sys.process.*
 import scala.collection.mutable.Map as MutMap
 import scala.jdk.CollectionConverters.*
 
-import vastblue.DriveRoot.*
-import vastblue.MountMapper.{mountMap, reverseMountMap}
+import vastblue.file.DriveRoot
+import vastblue.file.DriveRoot.*
+import vastblue.file.MountMapper
 import vastblue.file.Paths
 import vastblue.util.PathExtensions.*
 
@@ -868,7 +869,7 @@ object Platform {
 
   def cygpathM(pathstr: String): String = {
     val normed = pathstr.replace('\\', '/')
-    val tupes: Option[(String, String)] = reverseMountMap.find { case (k, v) =>
+    val tupes: Option[(String, String)] = MountMapper.reverseMountMap.find { case (k, v) =>
       val normtail = normed.drop(k.length)
       // detect whether a fstab prefix is an exactly match of a normed path string.
       normed.startsWith(k) && (normtail.isEmpty || normtail.startsWith("/"))
@@ -969,7 +970,7 @@ object Platform {
   def getPath(dir: String, s: String = ""): Path = Paths.get(s"$dir/$s")
 
   lazy val driveLetters: List[DriveRoot] = {
-    val values = mountMap.values.toList
+    val values = MountMapper.mountMap.values.toList
     val letters = {
       for {
         dl <- values.map { _.take(2) }
@@ -1132,7 +1133,7 @@ object Platform {
     (localMountMap, cd2r)
   }
 
-  lazy val cygdrivePrefix = reverseMountMap.get("cygdrive").getOrElse("")
+  lazy val cygdrivePrefix = MountMapper.reverseMountMap.get("cygdrive").getOrElse("")
 
   def fileLines(f: JFile): Seq[String] = {
     Using.resource(new BufferedReader(new FileReader(f))) { reader =>
@@ -1153,7 +1154,7 @@ object Platform {
 
   // this may be needed to replace `def canExist` in vastblue.os
   lazy val driveLettersLc: List[String] = {
-    val values = mountMap.values.toList
+    val values = MountMapper.mountMap.values.toList
     val letters = {
       for {
         dl <- values.map { _.take(2) }

--- a/src/main/scala/vastblue/Script.scala
+++ b/src/main/scala/vastblue/Script.scala
@@ -16,9 +16,13 @@ object Script {
     val stackList: List[StackTraceElement] = e.getStackTrace.toList
     val relevant: StackTraceElement = stackList.dropWhile( (e: StackTraceElement) =>
       val s = e.toString
-      s.startsWith("vastblue.") ||
-      s.contains("Script.scala") ||
-      s.contains("ArgsUtil.scala")
+      s.contains("unifile.") ||
+      s.contains("vastblue.Script.scala") ||
+      s.contains("vastblue.ArgsUtil.scala") ||
+      s.contains("vastblue.MainArgs") ||
+      s.contains("vastblue.util.") ||
+      s.contains("scalatest") ||
+      s.contains("junit")
     ).take(1) match {
       case Nil =>
         stackList.last

--- a/src/main/scala/vastblue/demo/BashPath.scala
+++ b/src/main/scala/vastblue/demo/BashPath.scala
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 
 import vastblue.unifile.*
 

--- a/src/main/scala/vastblue/demo/Find.scala
+++ b/src/main/scala/vastblue/demo/Find.scala
@@ -18,7 +18,7 @@ object Find {
         for (f <- walkTree(dir.toFile, maxdepth = parms.maxdepth)) {
           val p = f.toPath
           if (parms.matches(p)) {
-            printf("%s\n", p.relpath.posx)
+            printf("%s\n", p.relpath.stdpath)
           }
         }
       }

--- a/src/main/scala/vastblue/demo/PalletRef.scala
+++ b/src/main/scala/vastblue/demo/PalletRef.scala
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 
 import vastblue.unifile.*
 

--- a/src/main/scala/vastblue/demo/ShowMountMap.scala
+++ b/src/main/scala/vastblue/demo/ShowMountMap.scala
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 import vastblue.unifile.*
-import vastblue.MountMapper.*
+import vastblue.file.MountMapper.*
 
 object ShowMountMap {
   def main(args: Array[String]): Unit = {

--- a/src/main/scala/vastblue/demo/UnameGreeting.scala
+++ b/src/main/scala/vastblue/demo/UnameGreeting.scala
@@ -1,7 +1,7 @@
 //#!/usr/bin/env -S scala
 package vastblue.demo
 
-//> using lib "org.vastblue::unifile:0.2.2"
+//> using lib "org.vastblue::unifile:0.2.4"
 import vastblue.unifile.*
 
 object UnameGreeting {

--- a/src/main/scala/vastblue/file/DriveRoot.scala
+++ b/src/main/scala/vastblue/file/DriveRoot.scala
@@ -1,4 +1,4 @@
-package vastblue
+package vastblue.file
 
 import java.nio.file.{Path, Paths => JPaths}
 import vastblue.Platform.cygdrive

--- a/src/main/scala/vastblue/file/MountMapper.scala
+++ b/src/main/scala/vastblue/file/MountMapper.scala
@@ -1,11 +1,9 @@
-package vastblue
+package vastblue.file
 
-import vastblue.DriveRoot.*
 import vastblue.Platform.{_execLines, _notWindows, _pwd, _shellRoot, cygpathExe, posixrootBare, workingDrive}
+import vastblue.file.DriveRoot.*
 import vastblue.file.Util.readLines
 import vastblue.util.Utils.isAlpha
-//import vastblue.Platform.*
-//import vastblue.file.Paths.canExist
 import vastblue.util.PathExtensions.*
 import java.io.{File => JFile}
 import java.nio.file.Path
@@ -182,72 +180,6 @@ object MountMapper {
     }
     // replace multiple slashes with single slash
     cygMstr.replaceAll("//+", "/")
-  }
-
-//  lazy val DriveLetterColonPattern = "([a-zA-Z]):(.*)?".r
-//  lazy val CygdrivePattern         = s"${_cygdrive}([a-zA-Z])(/.*)?".r
-
-//  def pathsGetPrev(psxStr: String): Path = {
-//    val _normpath = psxStr.replace('\\', '/')
-//    val normpath = _normpath.take(_cygdrive.length+1) match {
-//    case dl if dl.startsWith("/") =>
-//      // apply mount map to paths with leading slash
-//      applyPosix2LocalMount(_normpath) // becomes absolute, if mounted
-//    case _ =>
-//      _normpath
-//    }
-//    def dd = driveRoot.toUpperCase.take(1)
-//    val (literalDrive, impliedDrive, pathtail) = normpath match {
-//    case DriveLetterColonPattern(dl, tail) => // windows drive letter
-//      (dl, dl, tail)
-//    case CygdrivePattern(dl, tail) => // cygpath drive letter
-//      (dl, dl, tail)
-//    case pstr if pstr.matches("/proc(/.*)?") => // /proc file system
-//      ("", "", pstr) // must not specify a drive letter!
-//    case pstr if pstr.startsWith("/") => // drive-relative path, with no drive letter
-//      // drive-relative paths are on the current-working-drive,
-//      ("", dd, pstr)
-//    case pstr => // relative path, implies default drive
-//      (dd, "", pstr)
-//    }
-//    val semipath          = Option(pathtail).getOrElse("/")
-//    val neededDriveLetter = if (impliedDrive.nonEmpty) s"$impliedDrive:" else ""
-//    val fpstr             = s"${neededDriveLetter}$semipath" // derefTilde(psxStr)
-//    if (literalDrive.nonEmpty) {
-//      // no need for cygpath if drive is unambiguous.
-//      val fpath =
-//        if (fpstr.endsWith(":") && fpstr.take(3).length == 2 && fpstr.equalsIgnoreCase(driveRoot)) {
-//          // fpstr is a drive letter expression.
-//          // Windows interprets a bare drive letter expression as
-//          // the "working directory" each drive had at jvm startup.
-//          _pwd
-//        } else {
-//          JPaths.get(fpstr)
-//        }
-//      normPath(fpath)
-//    } else {
-//      JPaths.get(fpstr)
-//    }
-//  }
-
-  def normPath(_pathstr: String): Path = {
-    val jpath: Path = _pathstr match {
-    case "~" => JPaths.get(sys.props("user.dir"))
-    case _   => JPaths.get(_pathstr)
-    }
-    normPath(jpath)
-  }
-
-  def normPath(path: Path): Path = try {
-    val s = path.toString
-    if (s.length == 2 && s.take(2).endsWith(":")) {
-      _pwd
-    } else {
-      path.toAbsolutePath.normalize
-    }
-  } catch {
-    case e: java.io.IOError =>
-      path
   }
 
   /*

--- a/src/main/scala/vastblue/file/Paths.scala
+++ b/src/main/scala/vastblue/file/Paths.scala
@@ -1,10 +1,9 @@
 package vastblue.file
 
-import vastblue.MountMapper.cygdrive
+import vastblue.file.MountMapper.cygdrive
 import vastblue.Platform
 import vastblue.Platform.{envPath, exeSuffix, shellDrive}
 import vastblue.file.Util.notWindows
-//import vastblue.Platform.*
 import vastblue.file.ProcfsPaths.*
 import vastblue.util.PathExtensions.*
 

--- a/src/main/scala/vastblue/file/Util.scala
+++ b/src/main/scala/vastblue/file/Util.scala
@@ -1,8 +1,9 @@
 package vastblue.file
 
 import vastblue.Platform.*
-import vastblue.{DriveRoot, Platform, Script}
-import vastblue.DriveRoot.*
+import vastblue.{Platform, Script}
+import vastblue.file.DriveRoot
+import vastblue.file.DriveRoot.*
 import vastblue.file.Util.*
 import vastblue.util.Utils.*
 import vastblue.math.Cksum

--- a/src/main/scala/vastblue/unifile.scala
+++ b/src/main/scala/vastblue/unifile.scala
@@ -5,7 +5,7 @@ import vastblue.util.ArgsUtil
 //import vastblue.util.ArgsUtil.*
 import vastblue.util.Utils
 import vastblue.file.Util
-import vastblue.MountMapper
+import vastblue.file.MountMapper
 import vastblue.util.PathExtensions
 
 import java.io.PrintWriter
@@ -16,30 +16,15 @@ object unifile extends PathExtensions {
 
   def cygdrive: String    = Platform.cygdrive
   def driveRoot: String   = Platform.driveRoot
-//  def pwd: Path           = Platform._pwd
-//  def isWinshell: Boolean = Platform._isWinshell
-//  def isWindows: Boolean  = Platform._isWindows
-//  def isLinux: Boolean    = Platform._isLinux
-//  def isWsl: Boolean      = Platform._unameLong.contains("WSL")
-
-  def normPath: String => Path = MountMapper.normPath
-//  def withFileWriter(p: Path, s: String = "UTF-8", b: Boolean = false)(func: PrintWriter => Any) =
-//    Platform.withFileWriter(p, s, b)(func)
-
   def isDirectory(path: String): Boolean = Platform.isDirectory(path)
 
   def where(basename: String): String                             = Platform._where(basename)
   def which(basename: String): String                             = Platform.which(basename)
   def find(basename: String, dirs: Seq[String] = envPath): String = Platform.which(basename)
 
-//  def propOrElse: (String, String) => String                      = Platform._propOrElse
-//  def propOrEmpty: String => String                               = Platform._propOrEmpty
-
-
   def isSameFile(p1: Path, p2: Path): Boolean   = util.Utils.isSameFile(p1, p2)
   def sameFile(s1: String, s2: String): Boolean = util.Utils.sameFile(s1, s2)
 
-//  def scriptName: String = Script.scriptName
   def prepArgs: Array[String] => Seq[String] = Platform.prepExecArgs
 
   def driveRelative(p: Path): Boolean                             = Utils.driveRelative(p)
@@ -54,45 +39,33 @@ object unifile extends PathExtensions {
 
   def driveAndPath(filepath: String)                              = Utils.driveAndPath(filepath)
 
-  //def segments(p: Path): Seq[Path]                                = Utils.segments(p)
-  //def canExist(p: Path): Boolean                                  = Platform.canExist(p)
 
   /*
-  def _usage: (String, Seq[String]) => Nothing    = ArgsUtil._usage
-  def thisArg: String                             = ArgsUtil.thisArg
-  def peekNext: String                            = ArgsUtil.peekNext
-  def consumeNext: String                         = ArgsUtil.consumeNext
+  def normPath: String => Path = MountMapper.normPath // JPaths, except for "~", but ...
+  def pwd: Path           = Platform._pwd
+  def isWinshell: Boolean = Platform._isWinshell
+  def isWindows: Boolean  = Platform._isWindows
+  def isLinux: Boolean    = Platform._isLinux
+  def isWsl: Boolean      = Platform._unameLong.contains("WSL")
+
+  def withFileWriter(p: Path, s: String = "UTF-8", b: Boolean = false)(func: PrintWriter => Any) =
+    Platform.withFileWriter(p, s, b)(func)
+
+  def scriptName: String                       = Script.scriptName
+  def propOrElse: (String, String) => String   = Platform._propOrElse
+  def propOrEmpty: String => String            = Platform._propOrEmpty
+  def segments(p: Path): Seq[Path]             = Utils.segments(p)
+  def canExist(p: Path): Boolean               = Platform.canExist(p)
+  def _usage: (String, Seq[String]) => Nothing = ArgsUtil._usage
+  def thisArg: String                          = ArgsUtil.thisArg
+  def peekNext: String                         = ArgsUtil.peekNext
+  def consumeNext: String                      = ArgsUtil.consumeNext
+  def scriptPath: Path                         = Script.scriptPath
+  def userhome: String                         = Utils.userhome
+  def eprint(xs: Any*): Unit                   = Script._eprint(xs:_*)
+  def eprintf(fmt: String, xs: Any*): Unit     = Script._eprintf(fmt, xs:_*)
 
   def eachArg(args: Seq[String], usage: (String) => Nothing = ArgsUtil.defaultUsage)(custom: String => Unit): Unit =
     ArgsUtil.eachArg(args, usage)(custom)
-  def scriptPath: Path   = Script.scriptPath
-  def userhome: String                                            = Utils.userhome
-  def eprint(xs: Any*): Unit                                      = Script._eprint(xs:_*)
-  def eprintf(fmt: String, xs: Any*): Unit                        = Script._eprintf(fmt, xs:_*)
-  def dirExists(pathstr: String): Boolean                         =z
-  def dirExists(path: Path): Boolean                              =z
-  def pathDriveletter(ps: String): String                         =z
-  def pathDriveletter(p: Path): String                            =z
-  def fileExists(p: Path): Boolean                                =z
-  def exists(path: String): Boolean                               =z
-  def dropshellDrive(str: String)                                 =z
-  def dropDriveLetter(str: String)                                =z
-  def asPosixPath(str: String)                                    =z
-  def asLocalPath(str: String)                                    =z
-  def fileLines(f: JFile): Seq[String]                            =z
-  def envOrElse(varname: String, elseValue: String = ""): String  =z
-  def normPath(_pathstr: String): Path                            =z
-  def normPath(path: Path): Path                                  =z
-  def pathSegments(path: String): (String, Seq[String])           =z
-  def dirIsCaseSensitiveUniversal(dir: JPath): Boolean            =z
-  def dirIsCaseSensitive(p: Path): Boolean                        =z
-  def _chmod(path: Path, permissions: String = "rw", allusers: Boolean = true): Boolean =z
-
-  lazy val fileRoots: List[String]                                =z
-  lazy val driveLettersLc: List[String]                           =z
-  lazy val herepath: Path                                         =z
-  lazy val PosixCygdrive                                          =z
-  lazy val LetterPath                                             =z
-  lazy val home: Path                                             =z
   */
 }

--- a/src/main/scala/vastblue/util/PathExtensions.scala
+++ b/src/main/scala/vastblue/util/PathExtensions.scala
@@ -249,7 +249,6 @@ trait PathExtensions {
     }
 
     def stdpath: String    = Platform.standardizePath(p.toAbsolutePath.normalize.toString.replace('\\', '/'))
-    def posixpath: String  = stdpath
     def dospath: String    = localpath.replace('/', '\\')
 
     def relpath: Path        = Util.relativize(p) // Platform?
@@ -425,7 +424,6 @@ trait PathExtensions {
 
     def relpath: Path             = f.toPath.relpath
     def stdpath: String           = Platform.standardizePath(f.toPath.toAbsolutePath.normalize.posx)
-    def posixpath: String         = f.toPath.stdpath
     def lastModifiedYMD: String   = f.path.lastModifiedYMD
     def parentPath: Path          = f.parentFile.toPath
     def parent: Path              = parentPath

--- a/src/main/scala/vastblue/util/Utils.scala
+++ b/src/main/scala/vastblue/util/Utils.scala
@@ -36,7 +36,7 @@ object Utils  {
     str
   }
 
-  lazy val herepath: Path = normPath(sys.props("user.dir"))
+  lazy val herepath: Path = JPaths.get(sys.props("user.dir"))
   def here = herepath.toString.replace('\\', '/')
 
   def driveAndPath(filepath: String) = {
@@ -126,27 +126,6 @@ object Utils  {
       val p1  = Paths.get(dir, "A")
       val p2  = Paths.get(dir, "a")
       p1.toAbsolutePath != p2.toAbsolutePath
-    }
-  }
-
-  def normPath(_pathstr: String): Path = {
-    val jpath: Path = _pathstr match {
-    case "~" => JPaths.get(sys.props("user.dir"))
-    case _   => JPaths.get(_pathstr)
-    }
-    normPath(jpath)
-  }
-  def normPath(path: Path): Path = {
-    try {
-      val s = path.toString
-      if (s.length == 2 && s.take(2).endsWith(":")) {
-        _pwd
-      } else {
-        path.toAbsolutePath.normalize
-      }
-    } catch {
-      case e: java.io.IOError =>
-        path
     }
   }
 

--- a/src/test/scala/MainSpec.scala
+++ b/src/test/scala/MainSpec.scala
@@ -12,8 +12,10 @@ class MainSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
     it ("should tolerate empty main.args") {
       val emptyArgs  = Array.ofDim[String](0)
       val argv       = prepArgv(emptyArgs.toSeq)
-      val thisScript = argv.head
-      var args       = argv.tail.toList
+      val main       = argv.headOption
+      printf("main: [%s]\n", main)
+      printf("argv: [%s]\n", argv)
+      assert(argv.size == 1) // argv(0) should reference main
     }
   }
 }

--- a/src/test/scala/TestUniPath.scala
+++ b/src/test/scala/TestUniPath.scala
@@ -1,6 +1,6 @@
 package vastblue
 
-import vastblue.MountMapper.*
+import vastblue.file.MountMapper.*
 import vastblue.file.Paths
 import vastblue.file.Paths.*
 import vastblue.Platform.*

--- a/src/test/scala/vastblue/RootRelativeTest.scala
+++ b/src/test/scala/vastblue/RootRelativeTest.scala
@@ -1,7 +1,7 @@
 package vastblue.file
 
 import vastblue.Platform.*
-import vastblue.MountMapper.*
+import vastblue.file.MountMapper.*
 import vastblue.file.Paths.*
 import vastblue.util.Utils.*
 import vastblue.util.PathExtensions.*

--- a/src/test/scala/vastblue/file/PathSpec.scala
+++ b/src/test/scala/vastblue/file/PathSpec.scala
@@ -62,7 +62,7 @@ class PathSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
     }
   }
 
-  describe("Path.relpath.posixpath") {
+  describe("Path.relpath.stdpath") {
     it("should correctly relativize Path, if below `pwd`") {
       val p     = Paths.get(s"${_pwd.posx}/src")
       val pabs: String = p.toAbsolutePath.normalize.toString.replace('\\', '/')
@@ -157,8 +157,8 @@ class PathSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
           // val b = file.toString.toLowerCase
           // val c = file.localpath.toLowerCase
           val d: String = file.dospath.toLowerCase
-          val df       = normPath(d)
-          val af       = normPath(a)
+          val df       = Paths.get(a)
+          val af       = Paths.get(d)
           val sameFile = isSameFile(af, df)
           def isPwd(s: String): Boolean = s == "." || s == pwdposx
           val equivalent = a == d || a.path.abs == d.path.abs
@@ -298,7 +298,7 @@ class PathSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
 
   def getVariants(p: Path): Seq[Path] = {
     val pstr = p.toString.toLowerCase
-    import vastblue.DriveRoot._
+    import vastblue.file.DriveRoot.*
     val stdpathToo = if (nonCanonicalDefaultDrive) Nil else Seq(p.stdpath)
 
     val variants: Seq[String] = Seq(
@@ -397,7 +397,7 @@ class PathSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
   lazy val TMP: String = {
     val driveLetter = "g"
     val driveRoot   = s"${cygroot}${driveLetter}"
-    if (vastblue.Platform.canExist(driveRoot.path)) {
+    if (canExist(driveRoot.path)) {
       val tmpdir = Paths.get(driveRoot)
       // val str = tmpdir.localpath
       tmpdir.isDirectory && tmpdir.paths.contains("/tmp") match {


### PR DESCRIPTION
- public interface accidentally included `normPath` and `posixPath` (removed)
- added test `MainSpec` to insure `prepArgv(main.args)` cannot crash when no args passed on command line

