### PR TITLE
v0.3.0 simplified PathExtensions getParent method with associated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Work with Posix paths in Windows, recognized mount points in `/etc/fstab`.
 
 To use `unifile` in an `SBT` project, add this dependency to `build.sbt`
 ```sbt
-  "org.vastblue" % "unifile_3" % "0.2.4"
+  "org.vastblue" % "unifile_3" % "0.3.0"
 ```
 For `scala` or `scala-cli` scripts, see examples below.
 
@@ -70,7 +70,7 @@ This example might surprise developers working in a `Windows` posix shell, since
 #!/ usr / bin / env -S scala -cli shebang
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile::0.2.4"
+//> using lib "org.vastblue::unifile::0.3.0"
 
 import vastblue.unifile.Paths
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ javacOptions ++= Seq("-source", "11", "-target", "11")
 
 //ThisBuild / envFileName   := "dev.env" // sbt-dotenv plugin gets build environment here
 ThisBuild / scalaVersion  := scalaVer
-ThisBuild / version       := "0.2.4"
+ThisBuild / version       := "0.3.0"
 ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / organization         := "org.vastblue"

--- a/jsrc/bashPath.sc
+++ b/jsrc/bashPath.sc
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 
 import vastblue.unifile.*
 

--- a/jsrc/bashPathCli.sc
+++ b/jsrc/bashPathCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 
 import vastblue.unifile.*
 

--- a/jsrc/fstabCli.sc
+++ b/jsrc/fstabCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 
 import vastblue.unifile.*
 

--- a/jsrc/palletRef.sc
+++ b/jsrc/palletRef.sc
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 
 import vastblue.unifile.*
 

--- a/jsrc/palletRefCli.sc
+++ b/jsrc/palletRefCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 
 import vastblue.unifile.*
 

--- a/jsrc/renameRemovePunctuation.sc
+++ b/jsrc/renameRemovePunctuation.sc
@@ -1,0 +1,192 @@
+#!/usr/bin/env -S scala
+//package vast.apps
+
+/**
+* Rename input files, removing punctuation.
+* Not intended to affect path separators, dots, hyphens or underscores.
+* First renames parent directories, then works its' way down the paths.
+*/
+import vastblue.pallet.*
+import vastblue.math.Cksum
+import scala.collection.immutable
+import scala.util.matching.Regex
+
+object RenameRemovePunctuation {
+  def usage(msg: String="") = {
+    _usage(msg,Seq(
+      "[-b] <base-directory> | <file1> [<file2> ...]",
+      "NOTE: <fileN> cannot be a directory.",
+      "-v      verbose (show each to-be-renamed file, etc.)",
+      "-b      show bad characters in files to-be-renamed"
+    ))
+  }
+  var dir: Option[Path] = None
+  var files = List.empty[Path]
+  var (verbose,showBadParts) = (false,false)
+
+  def main(args: Array[String]): Unit = {
+    parseArgs(args.toSeq)
+    var totalRenames = 0
+    try {
+      if( dir != None ){
+        totalRenames += renameWidthFirst(dir.get)
+      }
+      if( files.nonEmpty ){
+        for( f <- files ){
+          processPath(f)
+        }
+      }
+    } catch {
+    case e: Exception =>
+      eprintf("total renames so far [%s]\n", totalRenames)
+      showLimitedStack(e)
+      sys.exit(1)
+    }
+  }
+
+  def renameWidthFirst(dir: Path): Int = {
+    val renameCount = processPath(dir)
+    // eprintf("# %d\n",renameCount)
+    if( renameCount == 0 && dir.isDirectory ){
+      val (subfiles,subdirs) = dir.paths.partition { _.isFile }
+      if( subdirs.nonEmpty ){
+        if( verbose ) eprintf("# recurse into subdirs: [%s]\n",subdirs)
+        for( sub <- subdirs ){
+          renameWidthFirst(sub)
+        }
+      }
+      if( subfiles.nonEmpty ){
+        for( file <- subfiles ){
+          renameWidthFirst(file)
+        }
+      }
+    }
+    renameCount
+  }
+
+  def parseArgs(args: Seq[String]): Unit = {
+    if( args.isEmpty ){
+      usage()
+    }
+    eachArg(args.toSeq,usage){
+      case fname if Paths.get(fname).isDirectory =>
+        dir = Some(Paths.get(fname))
+      case fname if Paths.get(fname).isFile =>
+        files ::= Paths.get(fname)
+      case "-v" =>
+        verbose = true
+      case "-b" =>
+        showBadParts = true
+      case other =>
+        sys.error(s"not a file or a directory [$other]")
+    }
+    if( files.isEmpty && dir == None ){
+      dir = Some(Paths.get("."))
+    }
+  }
+    /*
+    if( file.toString.contains(" ") ){
+      eprintf("rename [%s] to ",file)
+      val (newFile, success) = file.renameRemovingCruft()
+      if( newFile.exists ){
+        eprintf("collision with mv '%s' %s\n",file.toString,newFile.toString)
+      }
+    }
+    */
+
+  lazy val pathChars = "[-:_a-zA-Z0-9\\./]"  // defines "legal" path characters
+  lazy val probChars: String = pathChars.replaceFirst("\\[","[^") // matches illegal portions of the path
+
+  lazy val bogusChars = " \t\b\r\n()@$~" // chars that should NOT appear in filenames
+  lazy val probSubstrings: immutable.IndexedSeq[String] = for {
+    i <- 0 until bogusChars.size
+    sub = bogusChars.substring(i,i+1)
+  } yield sub
+
+  lazy val NormalPathPattern: Regex = s"(${pathChars}+)".r
+  lazy val FunkyPathPattern: Regex = s"(.*)(${probChars}+)(.*)".r
+  lazy val q = "\""
+  def processPath(file: Path):Int = {
+    // sys.error(s"\nNormalPathPattern[${NormalPathPattern}]\nFunkyPathPattern[${FunkyPathPattern}]")
+    var renameNumber = 0
+    val spath = file.posx
+    if( spath.contains("(")){
+      hook += 1
+    }
+    spath match {
+    case NormalPathPattern(ff@_) =>
+//      eprintf("normal: %s\n",ff)
+    case FunkyPathPattern(pre,mid,post) =>
+      val badparts = reportDiscrepancy(file)
+      var fixed = spath.
+        replaceAll("[$]", "S").
+        replaceAll("[#]", "P").
+        replaceAll("[~]$", "9").
+        replaceAll(s"${probChars}+","-")
+
+      // we only want to modify the basename, not the parent path
+      val ff = fixed.split("/").reverse.toList
+      var last = ff.head
+      last = last.replaceAll("[-]{2,}","-")
+      last = last.replaceAll("^[-]+|[-_]+$","")
+      last = last.replaceAll("/[-]+","/")
+      last = last.replaceAll("[-]+/","/")
+      last = last.replaceAll("[-]+\\.",".")
+      fixed = (last :: ff.tail).reverse.mkString("/")
+
+      if( showBadParts || badparts.contains("$") || badparts.contains("~") ){
+        eprintf("# requires rename:\n file[%s]\n",file)
+        eprintf("fixed[%s]\n",fixed)
+        eprintf("pre[%s] mid[%s] post[%s]\n",pre,mid,post)
+        eprintf("file[%s]\nfixed[%s]\n",file,fixed)
+        eprintf("bad parts: [%s]\n",badparts)
+      }
+      val testFile = Paths.get(fixed)
+      eprintf("# rename file:\n# [%s]\n# [%s]\n",file.posx, testFile.posx)
+
+      val fileParent = file.parent.realpath.posx.toLowerCase
+      val testParent = testFile.parent.realpath.posx.toLowerCase
+      if( testParent != fileParent ){
+        eprintf("original file parent[%s]\n", fileParent)
+        eprintf("renamed  file parent[%s]\n", testParent)
+        sys.error(s"original file and intended rename not below same parent:\n${file.posx}\n${testFile.posx}")
+      }
+      def cksum(p: Path): String = {
+        val fname = p.posx
+        val (sum, size) = Cksum.gnuCksum(fname.getBytes)
+        sum.toString
+      }
+      if( testFile.exists ){
+        eprintf("%s\n", cksum(file))
+        eprintf("%s\n", cksum(testFile))
+        sys.error(s"collision: original file / intended rename already exists:\n${file.posx}\n${testFile.posx}")
+      }
+      val escapedFname = spath.replaceAll("([\\$])","\\\\$1")
+      printf("mv %s %s\n",q+escapedFname+q,q+fixed+q)
+      renameNumber += 1
+    case other =>
+      sys.error(s"other[$other]")
+    }
+    if( renameNumber > 0 && verbose ){
+      eprintf("processPath[%s]\n",file)
+    }
+    renameNumber
+  }
+  def shellExec2(str:String): List[String] = {
+    import scala.sys.process.*
+    val cmd = Seq(bashExe, "-c", str)
+    cmd.lazyLines_!.toList
+  }
+
+  def reportDiscrepancy(bf: Path):String = {
+//    val boge = probSubstrings
+    val ff = bf.stdpath
+    var offending = List.empty[String]
+    for( cc <- probSubstrings ){
+      if( ff.contains(cc) ){
+        offending ::= cc
+      }
+    }
+    offending.distinct.reverse.mkString("|")
+  }
+}

--- a/jsrc/sbt2cs.sc
+++ b/jsrc/sbt2cs.sc
@@ -1,0 +1,208 @@
+#!/usr/bin/env -S scala
+//package vast.apps
+
+import vastblue.unifile.*
+
+/*
+ * Options:
+ *   + fetch and list dependency file paths
+ *   + convert sbt dependencies to scala-cli "using dep" format
+ *
+ * Example conversion from sbt dependency format to scala-cli lib format:
+ *
+ * from:
+ *   org.vastblue             %% unifile       % 0.3.0
+ *   org.vastblue             %% pallet        % 0.10.5
+ *   org.scalanlp             %% breeze-viz    % 2.1.0
+ *   org.scalanlp             %% breeze        % 2.1.0
+ *   org.scala-lang.modules   %% scala-xml     % 2.2.0
+ *   org.scala-lang.modules   %% scala-swing   % 3.0.0
+ *   net.ruippeixotog         %% scala-scraper % 3.1.1
+ *   dev.ludovic.netlib       % blas           % 3.0.3
+ *   com.github.fommil.netlib % all            % 1.1.2
+ *   com.github.darrenjw      %% scala-glm     % 0.8
+ *
+ * to:
+ *   //> using dep "org.vastblue::pallet::0.10.5"
+ *   //> using dep "org.vastblue::unifile::0.3.0"
+ *   //> using dep "org.scalanlp::breeze-viz::2.1.0"
+ *   //> using dep "org.scalanlp::breeze::2.1.0"
+ *   //> using dep "org.scala-lang.modules::scala-xml::2.2.0"
+ *   //> using dep "org.scala-lang.modules::scala-swing::3.0.0"
+ *   //> using dep "net.ruippeixotog::scala-scraper::3.1.1"
+ *   //> using dep "dev.ludovic.netlib:blas:3.0.3"
+ *   //> using dep "com.github.fommil.netlib:all:1.1.2"
+ *   //> using dep "com.github.darrenjw::scala-glm::0.8"
+*/
+object Sbt2cs {
+  def usage(m: String=""): Nothing = {
+    _usage(m, Seq(
+      "[<inputFile>]",
+     s"[-sbt [<sbt-sourcefile>]   ; default: ${defaultSbtSource}",
+     s"[-cli]                     ; convert sbt deps to scala-cli format",
+     s"[-fetch]                   ; fetch and list lib jars",
+    ))
+  }
+  var (op, inputFile) = ("", "")
+
+  def main(args: Array[String]): Unit = {
+    try {
+      parseArgs(args.toSeq)
+      val entries = if (inputFile.nonEmpty && inputFile.path.isFile) {
+        val infile = inputFile.path
+        val cleaned = extractDeps(infile)
+        preProcessDeps(cleaned)
+      } else {
+        preProcessDeps(testData)
+      }
+      val deps = entries.map { SbtDep(_) }
+      op match {
+      case "" | "-fetch" =>
+        for (dep <- deps) {
+          for (line <- fetch(dep)) {
+            printf("%s\n", line.posx)
+          }
+        }
+      case "-cli" =>
+        for (line <- deps) {
+          printf("%s\n", asDep(line))
+        }
+      }
+    } catch {
+    case t: Throwable =>
+      showLimitedStack(t)
+      sys.exit(1)
+    }
+  }
+
+  lazy val testData = """
+org.scalanlp             %% breeze        % 2.1.0
+org.scala-lang.modules   %% scala-xml     % 2.2.0
+org.scalanlp             %% breeze        % 2.1.0
+org.scalanlp             %% breeze-viz    % 2.1.0
+dev.ludovic.netlib       % blas           % 3.0.3
+com.github.fommil.netlib % all            % 1.1.2
+com.github.darrenjw      %% scala-glm     % 0.8
+org.scala-lang.modules   %% scala-swing   % 3.0.0
+net.ruippeixotog         %% scala-scraper % 3.1.1
+org.vastblue             %% unifile       % 0.3.0
+org.vastblue             %% pallet        % 0.10.5
+""".trim.split("[\r\n]+").toList.filter { _.nonEmpty }
+
+  def parseArgs(args: Seq[String]): Unit = {
+    eachArg(args, usage) {
+    case "-cli" | "-fetch" =>
+      op = thisArg
+    case "-sbt" =>
+      if (peekNext.nonEmpty && !peekNext.startsWith("-") ) {
+        inputFile = consumeNext
+        if (!inputFile.path.isFile) {
+          usage(s"not found: ${inputFile}")
+        }
+      } else {
+        inputFile = defaultSbtSource
+      }
+    case f if !f.startsWith("-") && f.path.isFile =>
+      inputFile = f
+    case arg =>
+      usage(s"unrecognized arg [$arg]")
+    }
+  }
+
+  val defaultSbtSource = "/opt/ue/project/Dependencies.scala"
+
+  lazy val cs: String = find("cs")
+  lazy val repos = Seq(
+    "https://artifacts.alfresco.com/nexus/content/repositories/public/", // ldtp
+    "https://mvnrepository.com/artifact/com.snowtide",
+    "http://maven.snowtide.com/releases",
+  ).mkString("|")
+
+  def fetch(dep: SbtDep): Seq[String] = {
+    val depstr = dep.toString
+    if (dep.line.contains("ldtp")) {
+      val cmd = s"$cs fetch $depstr"
+      shellExec(cmd, Map("COURSIER_REPOSITORIES" -> repos))
+    } else {
+      execLines("cs", "fetch", depstr)
+    }
+  }
+
+  def asDep(image: SbtDep): String = {
+    s"//> using dep \"$image\""
+  }
+
+  case class SbtDep(_line: String) {
+    def doublePercent = _line.contains("%%")
+    val line = _line.replaceAll("[,\"]+", "")
+    val fields = line.split(" *%+ *").toList
+    val image = if (doublePercent) {
+      fields.mkString("::")
+    } else {
+      fields.mkString(":")
+    }
+    override def toString = image // s"//> using dep \"$image\""
+  }
+
+  def linesWithoutComments(p: Path): Seq[String] = {
+    var worklines = p.lines.map { line =>
+      // avoid treating https://blah-blah as containing // comment
+      s" $line"
+        .replaceAll("[^:]//.*", "")
+        .replaceAll(" *(test|withSources).*", "")
+        .replaceAll("[()\"]+", "")
+        .trim
+    }.filter { test =>
+      (test.contains("%") || test.trim.matches("^lazy val.*[0-9]")) &&
+      !test.contains("printf") &&
+      !test.contains("::Test") &&
+      !test.contains("scalacheck") &&
+      !test.contains("scalatest") &&
+      !test.contains("junit")
+    }
+    worklines
+  }
+
+  def extractDeps(infile: Path): Seq[String] = {
+    val filtered = linesWithoutComments(infile)
+    var (lazyvals, lines) = filtered.partition( _.startsWith("lazy val") )
+
+    var lazyvalMap = Map.empty[String, String]
+    lazyvals.foreach { (line: String) =>
+      val Seq(name, value) = line.split(" *= *").map { _.replaceAll("^lazy val *", "").replaceAll("[\"()]+", "") }.toSeq
+      // printf("[%s], [%s]\n", name, value)
+      lazyvalMap += (name -> value)
+    }
+    val valnames = lazyvalMap.keySet
+    def applyMap(line: String): String = {
+      val mapKey = valnames.find( (name: String) => line.contains(name) ).getOrElse("")
+      if (mapKey.nonEmpty) {
+        val mapValue = lazyvalMap(mapKey)
+        line.replace(mapKey, mapValue)
+      } else {
+        line
+      }
+    }
+
+    val cleaned = for {
+      line <- lines
+      fixed = applyMap(line)
+    } yield fixed
+    cleaned
+  }
+
+  def preProcessDeps(cleaned: Seq[String]): Seq[String] = {
+    val sorted = cleaned.sortWith ((a, b) =>
+      if (a.contains("unifile")) true else
+      if (a.contains("pallet")) true else
+      if (a.contains("vast")) true else
+      if (a.contains("apps")) true else
+      if (b.contains("unifile")) false else
+      if (b.contains("pallet")) false else
+      if (b.contains("vast")) false else
+      if (a.contains("apps")) false else
+      a > b // reverse (unifile before pallet)
+    )
+    sorted.distinct
+  }
+}

--- a/jsrc/unameGreeting.sc
+++ b/jsrc/unameGreeting.sc
@@ -1,7 +1,7 @@
 //#!/usr/bin/env -S scala
 package vastblue.demo
 
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 import vastblue.unifile.*
 
 object UnameGreeting {

--- a/jsrc/unameGreetingCli.sc
+++ b/jsrc/unameGreetingCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 
 import vastblue.unifile.*
 

--- a/src/main/scala/vastblue/Script.scala
+++ b/src/main/scala/vastblue/Script.scala
@@ -55,9 +55,9 @@ object Script {
   def _scriptPath: String = _propOrElse("script.path", _scriptProp.filePath)
   def scriptName: String  = _scriptPath match {
   case "" | "MainArgs.scala" | "mainargs.scala" | "Script.scala" =>
-    scriptProp().filePath
+    scriptProp().filePath.posx
   case name =>
-    name
+    name.posx
   }
   extension(e: StackTraceElement) {
     def filePath: String = {

--- a/src/main/scala/vastblue/demo/BashPath.scala
+++ b/src/main/scala/vastblue/demo/BashPath.scala
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 
 import vastblue.unifile.*
 

--- a/src/main/scala/vastblue/demo/PalletRef.scala
+++ b/src/main/scala/vastblue/demo/PalletRef.scala
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 
 import vastblue.unifile.*
 

--- a/src/main/scala/vastblue/demo/UnameGreeting.scala
+++ b/src/main/scala/vastblue/demo/UnameGreeting.scala
@@ -1,7 +1,7 @@
 //#!/usr/bin/env -S scala
 package vastblue.demo
 
-//> using lib "org.vastblue::unifile:0.2.4"
+//> using lib "org.vastblue::unifile:0.3.0"
 import vastblue.unifile.*
 
 object UnameGreeting {

--- a/src/main/scala/vastblue/file/MountMapper.scala
+++ b/src/main/scala/vastblue/file/MountMapper.scala
@@ -170,7 +170,7 @@ object MountMapper {
         val dl: String = normed.drop(1).take(1) + ":"
         normed.drop(2) match {
         case "" =>
-          s"$dl/" // trailing slash is required here
+          s"$dl/" // trailing slash is needed here
         case str =>
           s"$dl$str"
         }
@@ -187,7 +187,7 @@ object MountMapper {
    * else by adding shellRoot prefix (if `driveRelative`)
    */
   def applyPosix2LocalMount(pathstr: String): String = {
-    require(pathstr.take(2).last != ':', s"bad argument : ${pathstr}")
+    require(!pathstr.take(2).endsWith(":"), s"bad argument : ${pathstr}")
     if (pathstr == "/etc/fstab") {
       hook += 1
     }

--- a/src/main/scala/vastblue/file/Paths.scala
+++ b/src/main/scala/vastblue/file/Paths.scala
@@ -79,7 +79,7 @@ object Paths {
     val _pathstr = derefTilde(_fnamestr) // replace leading tilde with sys.props("user.home")
 
     val psxStr = _pathstr.replace('\\', '/')
-    require(legalPosixFilename(psxStr))
+    //require(legalPosixFilename(psxStr), s"filename not legal: [$_pathstr]")
 
     val p: Path = {
       if (psxStr.startsWith(s"$pwdposx/")) {

--- a/src/main/scala/vastblue/file/Paths.scala
+++ b/src/main/scala/vastblue/file/Paths.scala
@@ -2,7 +2,7 @@ package vastblue.file
 
 import vastblue.file.MountMapper.cygdrive
 import vastblue.Platform
-import vastblue.Platform.{envPath, exeSuffix, shellDrive}
+import vastblue.Platform.{envPath, exeSuffix, shellDrive, legalPosixFilename }
 import vastblue.file.Util.notWindows
 import vastblue.file.ProcfsPaths.*
 import vastblue.util.PathExtensions.*
@@ -79,6 +79,7 @@ object Paths {
     val _pathstr = derefTilde(_fnamestr) // replace leading tilde with sys.props("user.home")
 
     val psxStr = _pathstr.replace('\\', '/')
+    require(legalPosixFilename(psxStr))
 
     val p: Path = {
       if (psxStr.startsWith(s"$pwdposx/")) {

--- a/src/test/scala/vastblue/PathnameTest.scala
+++ b/src/test/scala/vastblue/PathnameTest.scala
@@ -67,7 +67,7 @@ class PathnameTest extends AnyFunSpec with Matchers with BeforeAndAfter with Pat
     for (testfilename <- testfilenames) {
       it(s"should correctly handle filename [$testfilename] ") {
         val testfile = Paths.get(testfilename)
-        val testPossible = testfile.parentFile match {
+        val testPossible = testfile.parent match {
         case dir if dir.isDirectory =>
           true
         case _ =>

--- a/src/test/scala/vastblue/TestInvariants.scala
+++ b/src/test/scala/vastblue/TestInvariants.scala
@@ -15,7 +15,7 @@ class TestInvariants extends AnyFunSpec with Matchers with BeforeAndAfter {
       printf("hd [%s]\n", hd.toString)
       val workingDrive: String = Platform.workingDrive.string
       printf("workingDrive [%s]\n", workingDrive)
-      assert(hd equalsIgnoreCase workingDrive)
+      assert(hd.isEmpty == workingDrive.isEmpty)
       it (" should be correct for os") {
         if (isWindows) {
           assert(hereDrive.matches("[a-zA-Z]:"))

--- a/src/test/scala/vastblue/TestInvariants.scala
+++ b/src/test/scala/vastblue/TestInvariants.scala
@@ -15,15 +15,16 @@ class TestInvariants extends AnyFunSpec with Matchers with BeforeAndAfter {
       printf("hd [%s]\n", hd.toString)
       val workingDrive: String = Platform.workingDrive.string
       printf("workingDrive [%s]\n", workingDrive)
-      assert(hd.isEmpty == workingDrive.isEmpty)
       it (" should be correct for os") {
         if (isWindows) {
+          assert(hd equalsIgnoreCase workingDrive)
           assert(hereDrive.matches("[a-zA-Z]:"))
         } else {
           assert(hereDrive.isEmpty)
         }
       }
     }
+
     describe("pwd") {
       it ("should be correct wrt rootDrive for os") {
         val workingDrive: String = Platform.workingDrive.string

--- a/src/test/scala/vastblue/TestInvariants.scala
+++ b/src/test/scala/vastblue/TestInvariants.scala
@@ -12,7 +12,9 @@ class TestInvariants extends AnyFunSpec with Matchers with BeforeAndAfter {
     // verify test invariants
     describe ("working drive") {
       val hd = Platform.hereDrive
+      printf("hd [%s]\n", hd.toString)
       val workingDrive: String = Platform.workingDrive.string
+      printf("workingDrive [%s]\n", workingDrive)
       assert(hd equalsIgnoreCase workingDrive)
       it (" should be correct for os") {
         if (isWindows) {

--- a/src/test/scala/vastblue/file/PathSpec.scala
+++ b/src/test/scala/vastblue/file/PathSpec.scala
@@ -242,6 +242,46 @@ class PathSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
   }
 
   describe("Path") {
+    describe("# bare filename") {
+      it ("bare path segments are valid files") {
+        val s1 = Paths.get("s1")
+        val stdpath = s1.stdpath
+        assert(stdpath.startsWith("/"))
+      }
+      it ("bare filenames always have parent files") {
+        val s1 = Paths.get("s1")
+        val p1: Path = s1.getParentPath
+        val par = s1.toAbsolutePath.parent
+        assert(par != null)
+      }
+    }
+    describe("# getParentPath extension method") {
+      val windowsPaths: List[String] = if (isWindows) {
+        List(
+          "C:",
+          "C:/",
+        )
+      } else {
+        Nil
+      }
+      val testPaths: List[String] = windowsPaths
+      ::: List(
+        ".",
+        "src",
+        "/",
+        "/bin",
+      )
+
+      for (pathstr <- testPaths.distinct) {
+        it(s"does not return null on $pathstr") {
+          val p = Paths.get(pathstr)
+          val par = p.getParentPath
+          eprintf("par [%s]\n", par.posx)
+          assert(par != null)
+        }
+      }
+    }
+
     describe("# round trip consistency") {
       for (fname <- distinctKeys) {
         val f1: Path            = Paths.get(fname)

--- a/src/test/scala/vastblue/file/PathSpec.scala
+++ b/src/test/scala/vastblue/file/PathSpec.scala
@@ -24,11 +24,11 @@ class PathSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
   describe ("invariants") {
     // verify test invariants
     describe ("working drive") {
+      val hd = Platform.hereDrive
+      val workingDrive: String = Platform.workingDrive.string
       it (" should be correct for os") {
-        val hd = Platform.hereDrive
-        val workingDrive: String = Platform.workingDrive.string
-        assert(hd equalsIgnoreCase workingDrive)
         if (isWindows) {
+          assert(hd equalsIgnoreCase workingDrive)
           assert(hd.matches("[a-zA-Z]:"))
         } else {
           assert(hd.isEmpty)


### PR DESCRIPTION
Added `getParentPath` to `java.nio.file.Path` as the preferred method for acquiring a parentFile.
Added methods to verify whether a filename is "valid", meaning that the filename belongs to the common legal subset of filenames on all major `OS` types.   This is helpful when writing portable code.

The standard methods for deriving a parent directory from a `java.nio.file.Path` or a `java.io.File` object often return `null`.

The new `getParentPath` method and convenience methods based it should never return `null` for valid `Path` objects.
The convention is to treat the `root` path as it's own parent.

New tests added.

