### PR TITLE
fix cksum for files bigger than 2GB / added walkTreeFast with closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This library provides the missing piece.
 This example might surprise developers working in a `Windows` posix shell, since `jvm` languages normally cannot see posix file paths that aren't also legal `Windows` paths.
 
 ```scala
-#!/ usr / bin / env -S scala -cli shebang
+#!/usr/bin/env -S scala -cli shebang
 
 //> using scala "3.3.1"
 //> using lib "org.vastblue::unifile::0.3.1"
@@ -76,7 +76,7 @@ import vastblue.unifile.Paths
 
 object FstabCli {
   def main(args: Array[String]): Unit = {
-    // `posixroot` is the native path corresponding to "/"
+    // `shellRoot` is the native path corresponding to "/"
     // display the native path and lines.size of /etc/fstab
     val p = Paths.get("/etc/fstab")
     val lines = java.nio.file.Files.readAllLines(p).asScala.toSeq
@@ -89,11 +89,11 @@ FstabCli.main(args)
 ```
 ### Output of the previous example scripts on various platforms:
 ```
-Linux Mint # env: GNU/Linux | posixroot: /           | /etc/fstab            | 21 lines
-Darwin     # env: Darwin    | posixroot: /           | /etc/fstab            | 0 lines
-WSL Ubuntu # env: GNU/Linux | posixroot: /           | /etc/fstab            | 6 lines
-Cygwin64   # env: Cygwin    | posixroot: C:/cygwin64 | C:/cygwin64/etc/fstab | 24 lines
-Msys64     # env: Msys      | posixroot: C:/msys64/  | C:/msys64/etc/fstab   | 22 lines
+Linux Mint # env: GNU/Linux | shellRoot: /           | /etc/fstab            | 21 lines
+Darwin     # env: Darwin    | shellRoot: /           | /etc/fstab            | 0 lines
+WSL Ubuntu # env: GNU/Linux | shellRoot: /           | /etc/fstab            | 6 lines
+Cygwin64   # env: Cygwin    | shellRoot: C:/cygwin64 | C:/cygwin64/etc/fstab | 24 lines
+Msys64     # env: Msys      | shellRoot: C:/msys64/  | C:/msys64/etc/fstab   | 22 lines
 ```
 Note that on Darwin, there is no `/etc/fstab` file, so the `Path#lines` extension returns `Nil`.
 

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,9 @@ resolvers += Resolver.mavenLocal
 
 publishTo := sonatypePublishToBundle.value
 
+Compile / packageBin / packageOptions +=
+  Package.ManifestAttributes(java.util.jar.Attributes.Name.CLASS_PATH -> "")
+
 lazy val root = (project in file(".")).
   enablePlugins(BuildInfoPlugin).
   settings(

--- a/jsrc/bashPath.sc
+++ b/jsrc/bashPath.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 //> using scala "3.3.1"
 //> using lib "org.vastblue::unifile:0.3.1"
@@ -7,9 +7,9 @@ package vastblue.demo
 import vastblue.unifile.*
 
 object BashPath {
-  lazy val bashPath = where("bash").path
+  val bashPath = where("bash").path
 
-  def main(args: Array[String]): Unit =
+  def main(args: Array[String]): Unit = {
     printf("userhome: [%s]\n", userhome)
     import scala.sys.process.*
     val progname = if (isWindows) {
@@ -24,4 +24,5 @@ object BashPath {
     printf("%s\n", bashPath.toRealPath())
     printf("shellRoot: %s\n", shellRoot)
     printf("sys root:  %s\n", where("bash").posx.replaceAll("(/usr)?/bin/bash.*", ""))
+  }
 }

--- a/jsrc/bashPathCli.sc
+++ b/jsrc/bashPathCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.3.1"
+//> using dep "org.vastblue::unifile:0.3.1"
 
 import vastblue.unifile.*
 

--- a/jsrc/cmdInfo.sc
+++ b/jsrc/cmdInfo.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/jsrc/decoder.sc
+++ b/jsrc/decoder.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala -cp target/scala-3.3.1/classes
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/jsrc/demo.sc
+++ b/jsrc/demo.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala @./atFile
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 import vastblue.MainArgs

--- a/jsrc/dirlist.sc
+++ b/jsrc/dirlist.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala @./atFile
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/jsrc/dummyCmdline.sc
+++ b/jsrc/dummyCmdline.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.Script.*
 

--- a/jsrc/find.sc
+++ b/jsrc/find.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala @${HOME}/.scala3cp
-package vastblue.demo
+//package vastblue.demo
 
 // hash bang line error on OSX/Darwin due to non-gnu /usr/bin/env
 // portable way to set classpath:

--- a/jsrc/fstab.sc
+++ b/jsrc/fstab.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/jsrc/fstabCli.sc
+++ b/jsrc/fstabCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.3.1"
+//> using dep "org.vastblue::unifile:0.3.1"
 
 import vastblue.unifile.*
 

--- a/jsrc/globArg.sc
+++ b/jsrc/globArg.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala -cp target/scala-3.3.1/classes
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/jsrc/hostname.sc
+++ b/jsrc/hostname.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala -cp target/scala-3.3.1/classes
-package vastblue.demo
+//package vastblue.demo
 
 object Hostname {
   def main(args: Array[String]): Unit =

--- a/jsrc/mainName.sc
+++ b/jsrc/mainName.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala -deprecation
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/jsrc/nativePathString.sc
+++ b/jsrc/nativePathString.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 import vastblue.file.Util.*

--- a/jsrc/ownPid.sc
+++ b/jsrc/ownPid.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala @./.scala3cp -deprecation
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 import vastblue.MainArgs

--- a/jsrc/palletRef.sc
+++ b/jsrc/palletRef.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 //> using scala "3.3.1"
 //> using lib "org.vastblue::unifile:0.3.1"

--- a/jsrc/palletRefCli.sc
+++ b/jsrc/palletRefCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.3.1"
+//> using dep "org.vastblue::unifile:0.3.1"
 
 import vastblue.unifile.*
 

--- a/jsrc/pathStrings.sc
+++ b/jsrc/pathStrings.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/jsrc/procCmdline.sc
+++ b/jsrc/procCmdline.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala -deprecation
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.Platform.*
 import vastblue.file.ProcfsPaths.*

--- a/jsrc/procTest.sc
+++ b/jsrc/procTest.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 import vastblue.file.ProcfsPaths.*

--- a/jsrc/procTests.sc
+++ b/jsrc/procTests.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala -cp target/scala-3.3.1/classes
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 import vastblue.file.ProcfsPaths.*

--- a/jsrc/sbt2cs.sc
+++ b/jsrc/sbt2cs.sc
@@ -12,7 +12,7 @@ import vastblue.unifile.*
  *
  * from:
  *   org.vastblue             %% unifile       % 0.3.1
- *   org.vastblue             %% pallet        % 0.10.5
+ *   org.vastblue             %% pallet        % 0.10.7
  *   org.scalanlp             %% breeze-viz    % 2.1.0
  *   org.scalanlp             %% breeze        % 2.1.0
  *   org.scala-lang.modules   %% scala-xml     % 2.2.0
@@ -23,7 +23,7 @@ import vastblue.unifile.*
  *   com.github.darrenjw      %% scala-glm     % 0.8
  *
  * to:
- *   //> using dep "org.vastblue::pallet::0.10.5"
+ *   //> using dep "org.vastblue::pallet::0.10.7"
  *   //> using dep "org.vastblue::unifile::0.3.1"
  *   //> using dep "org.scalanlp::breeze-viz::2.1.0"
  *   //> using dep "org.scalanlp::breeze::2.1.0"
@@ -86,7 +86,7 @@ com.github.darrenjw      %% scala-glm     % 0.8
 org.scala-lang.modules   %% scala-swing   % 3.0.0
 net.ruippeixotog         %% scala-scraper % 3.1.1
 org.vastblue             %% unifile       % 0.3.1
-org.vastblue             %% pallet        % 0.10.5
+org.vastblue             %% pallet        % 0.10.7
 """.trim.split("[\r\n]+").toList.filter { _.nonEmpty }
 
   def parseArgs(args: Seq[String]): Unit = {

--- a/jsrc/showMainArgs.sc
+++ b/jsrc/showMainArgs.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala @./atFile
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/jsrc/showMountMap.sc
+++ b/jsrc/showMountMap.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 import vastblue.file.MountMapper.*

--- a/jsrc/showPlatform.sc
+++ b/jsrc/showPlatform.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala @./atFile
-package vastblue.demo
+//package vastblue.demo
 
-import vastblue.Platform.{_mountMap, cygdrive2root, cygpathExe, cygpathM, etcdir, exeSuffix, findAllInPath, winshellBinDirs}
+import vastblue.Platform.{cygpathExe, cygpathM, etcdir, exeSuffix, findAllInPath, winshellBinDirs}
 import vastblue.unifile.*
 
 object ShowPlatform {
@@ -32,8 +32,7 @@ object ShowPlatform {
     printf("whichExe     [%s]\n", whichExe)
     printf("hostname     [%s]\n", hostname)
     printf("etcdir       [%s]\n", etcdir)
-    printf("cygdrive2root[%s]\n", cygdrive2root)
-    val ls = which("ls")
+    val ls = where("ls")
     printf("which ls     [%s]\n", ls.path.stdpath)
     val lspath = cygpathM(ls)
     printf("cygpath ls   [%s]\n", lspath)

--- a/jsrc/testversions.sc
+++ b/jsrc/testversions.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala @./atFile
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 import scala.sys.process.*

--- a/jsrc/unameGreeting.sc
+++ b/jsrc/unameGreeting.sc
@@ -1,5 +1,5 @@
 //#!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 //> using lib "org.vastblue::unifile:0.3.1"
 import vastblue.unifile.*

--- a/jsrc/unameGreetingCli.sc
+++ b/jsrc/unameGreetingCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.3.1"
-//> using lib "org.vastblue::unifile:0.3.1"
+//> using dep "org.vastblue::unifile:0.3.1"
 
 import vastblue.unifile.*
 

--- a/jsrc/wait.sc
+++ b/jsrc/wait.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/jsrc/where.sc
+++ b/jsrc/where.sc
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S scala
-package vastblue.demo
+//package vastblue.demo
 
 import vastblue.unifile.*
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,10 @@
 val SONATYPE_VERSION = sys.env.getOrElse("SONATYPE_VERSION", "3.10.0") // "3.9.21")
 
+scalaVersion := "2.12.19"
 //addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
 
-addSbtPlugin("ch.epfl.scala"  % "sbt-bloop"     % "1.5.13")
-addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"  % "0.11.1")
+addSbtPlugin("ch.epfl.scala"  % "sbt-bloop"     % "1.5.15")
+addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"  % "0.12.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype"  % SONATYPE_VERSION)
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"  % "2.5.2")
 addSbtPlugin("com.github.sbt" % "sbt-dynver"    % "5.0.1")

--- a/src/main/scala/vastblue/Platform.scala
+++ b/src/main/scala/vastblue/Platform.scala
@@ -682,9 +682,6 @@ object Platform {
     }
   }
 
-  lazy val posixrootBare = {
-    posixroot.reverse.dropWhile(_ == '/').reverse
-  }
   lazy val posixroot: String = {
     if (_notWindows) {
       "/"
@@ -1141,7 +1138,7 @@ object Platform {
     var cd2r          = true // by default /c should mount to c:/ in windows
     if (_isWindows) {
       // cygwin provides default values, potentially overridden in fstab
-      val rr = posixrootBare
+      val rr = posixroot.reverse.dropWhile(_ == '/').reverse
       localMountMap += "/usr/bin" -> s"$rr/bin"
       localMountMap += "/usr/lib" -> s"$rr/lib"
       // next 2 are convenient, but MUST be added before reading fstab

--- a/src/main/scala/vastblue/file/MountMapper.scala
+++ b/src/main/scala/vastblue/file/MountMapper.scala
@@ -1,6 +1,6 @@
 package vastblue.file
 
-import vastblue.Platform.{_execLines, _notWindows, _pwd, _shellRoot, cygpathExe, posixrootBare, workingDrive}
+import vastblue.Platform.{_execLines, _notWindows, _pwd, _shellRoot, cygpathExe, workingDrive}
 import vastblue.file.DriveRoot.*
 import vastblue.file.Util.readLines
 import vastblue.util.Utils.isAlpha
@@ -213,7 +213,7 @@ object MountMapper {
           // looks like a cygdrive designator replace '/cygdrive/X' with 'X:/'
           s"$firstSeg:/${segments.tail.mkString("/")}"
         } else {
-          val rr = posixrootBare
+          val rr = shellRoot
           s"$rr$pathstr"
         }
       } else {

--- a/src/main/scala/vastblue/file/TreeWalker.scala
+++ b/src/main/scala/vastblue/file/TreeWalker.scala
@@ -1,0 +1,68 @@
+//#!/usr/bin/env -S scala -deprecation
+package vastblue.file
+
+import java.io._
+import java.nio.file.{Path, Paths}
+import java.nio.file.attribute._
+import java.nio.file._
+import java.nio.file.FileVisitResult._
+import java.nio.file.FileVisitOption._
+import scala.io.Source
+
+object TreeWalker {
+  def main(args: Array[String]): Unit = {
+    try {
+      val dir = Paths.get("F:/")
+      val sfx = ".mp4"
+      var maxdepth = -1
+      var tossDirs = Set(".git", "target") // ignore these
+      walkTreeFast(dir, tossDirs, maxdepth = -1) { (p: Path) =>
+        val name: String = p.toFile.getName
+        val ok = name.endsWith(sfx)
+        if (ok) printf("%s\n", p.toAbsolutePath.toString.replace('\\', '/'))
+        ok
+      }
+    } catch {
+    case t: Throwable =>
+      //t.printStackTrace()
+      import vastblue.file.Util.*
+      _showLimitedStack(t)
+      sys.exit(1)
+    }
+  }
+
+  // Walk directory tree:
+  //   recovers from permission security exceptions
+  //   much faster than Files.walk
+  // Caveat: in Windows, pukes if directory name has trailing dot
+  def walkTreeFast(dir: Path, tossDirs: Set[String] = Set.empty[String], maxdepth: Int = -1)(filt: Path => Boolean): (Long, Long)  = {
+    class TreeWalker(examine: Path => Boolean) extends SimpleFileVisitor[Path] {
+      var (visited, matched) = (0L, 0L)
+      def stats: (Long, Long) = (visited, matched)
+
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        visited += 1
+        matched += (if examine(file) then 1 else 0)
+        CONTINUE
+      }
+
+      override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        val name = dir.toFile.getName
+        if (tossDirs.contains(name)) {
+          SKIP_SUBTREE
+        } else {
+          CONTINUE
+        }
+      }
+
+      override def visitFileFailed(p: Path, e: IOException): FileVisitResult = {
+        System.err.println(e)
+        CONTINUE
+      }
+    }
+
+    val examiner = new TreeWalker(filt)
+    Files.walkFileTree(dir, examiner)
+    examiner.stats
+  }
+}

--- a/src/main/scala/vastblue/file/Util.scala
+++ b/src/main/scala/vastblue/file/Util.scala
@@ -860,8 +860,9 @@ object Util {
   }
 
   // windows-specific
-  def isWindowsJunction(filename:String, enable:Boolean=true):(Boolean, String) = {
+  def isWindowsJunction(_filename: String, enable: Boolean=true): (Boolean, String) = {
     import scala.sys.process.*
+    val filename = Paths.get(_filename).toAbsolutePath.normalize.toString.replace('\\', '/')
     // also known as a junction point
     var (junctionFlag, substituteName) = (false, "")
     if( isWindows && enable ){

--- a/src/main/scala/vastblue/unifile.scala
+++ b/src/main/scala/vastblue/unifile.scala
@@ -16,9 +16,9 @@ object unifile extends PathExtensions {
 
   def cygdrive: String    = Platform.cygdrive
   def driveRoot: String   = Platform.driveRoot
+  def posixroot: String   = Platform.posixroot
   def isDirectory(path: String): Boolean = Platform.isDirectory(path)
 
-  def where(basename: String): String                             = Platform._where(basename)
   def which(basename: String): String                             = Platform.which(basename)
   def find(basename: String, dirs: Seq[String] = envPath): String = Platform.which(basename)
 

--- a/src/main/scala/vastblue/util/PathExtensions.scala
+++ b/src/main/scala/vastblue/util/PathExtensions.scala
@@ -117,7 +117,14 @@ trait PathExtensions {
 
   def eachArg: (Seq[String], String => Nothing) => (String => Unit) => Unit = ArgsUtil.eachArg _
 
+  def walkTreeFast(p: Path, tossDirs: Set[String], maxdepth: Int = -1)(filt: Path => Boolean): (Long, Long) = {
+    vastblue.file.TreeWalker.walkTreeFast(p, tossDirs, maxdepth)(filt)
+  }
   def walkTree(file: JFile, depth: Int = 1, maxdepth: Int = -1): Iterable[JFile] = vastblue.file.Util.walkTree(file, depth, maxdepth)
+
+  def walkTreeFiltered(file: JFile, depth: Int = 1, maxdepth: Int = -1)(filt: JFile => Boolean): Iterable[JFile] = {
+    vastblue.file.Util.walkTreeFiltered(file, depth, maxdepth)(filt)
+  }
 
 //  def filesTree(dir: JFile)(func: JFile => Boolean = Util.dummyFilter): Seq[JFile] = vastblue.file.Util.filesTree(dir.toFile)(func)
 
@@ -183,6 +190,13 @@ trait PathExtensions {
 
     //def lastModifiedTime        = whenModified(p.toFile)
     def lastModified: Long        = p.toFile.lastModified
+
+    def newerThan(other: Path): Boolean = {
+      p.isFile && other.isFile && other.lastModified > p.lastModified
+    }
+    def olderThan(other: Path): Boolean = {
+      p.isFile && other.isFile && other.lastModified < p.lastModified
+    }
 
     def lastModifiedMillisAgo: Long  = System.currentTimeMillis - p.toFile.lastModified
     def lastModSecondsAgo: Double    = (lastModifiedMillisAgo/1000L).toDouble
@@ -445,7 +459,7 @@ trait PathExtensions {
 
     // comparable to Some(dotsuffix):
     def extension: Option[String] = f.getName.reverse match {
-      case s if s.contains(".") && !s.endsWith(".") => Some(s.dropWhile(_!='.').reverse)
+      case s if s.contains(".") && !s.endsWith(".") => Some(s.reverse.dropWhile(_!='.'))
       case s => None
     }
     def renameTo(s: String): Boolean = renameTo(s.path)


### PR DESCRIPTION
Added an extension method to `java.nio.file.Path`:

```scala
+  def walkTreeFast(p: Path, tossDirs: Set[String], maxdepth: Int = -1)(filt: Path => Boolean): (Long, Long) = {
+    vastblue.file.TreeWalker.walkTreeFast(p, tossDirs, maxdepth)(filt)
+  }
```
`tossDirs` is a Set of names of subfile trees to be skipped over, e.g., `target`, `.git`, `tmp`, etc.

updated dependencies to address a `Dependabot` security issue for  `com.google.protobuf:protobuf < 3.6.1`.


