### PR TITLE
V0.4.1 release

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -7,28 +7,28 @@ name: Scala CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ main ]
   pull_request:
-    branches: [ "main" ]
-
-permissions:
-  contents: read
+    branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: 'sbt'
-    - name: Run tests
+        java-version: 11
+        distribution: temurin
+
+    - name: Install sbt
+      run: |
+        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 99E82A75642AC823
+        echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
+        sudo apt-get update
+        sudo apt-get install sbt
+
+    - name: sbt test
       run: sbt test
-      # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository
-#   - name: Upload dependency graph
-#     uses: scalacenter/sbt-dependency-submission@ab086b50c947c9774b70f39fc7f6e20ca2706c91

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 + Simplify system administration tasks.
 + no 3rd party libraries, 100% scala.
 
-For this functionality, plus reading of `.csv`, expressive Date & Time functions, and more, see [Pallet](https://github.com/philwalk/pallet) instead (has 3rd party dependencies).
+For `unifile` functionality, reading of `.csv`, Date & Time functions, and more, see [Pallet](https://github.com/philwalk/pallet) (has 3rd party dependencies).
 
 Write portable code that runs on Linux, Mac, or Windows.
 Converting path Strings to `java.nio.file.Path` objects.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Recognizes `posix` file paths in Windows, via customizable mount points in `C:/m
 
 To use `unifile` in an `SBT` project, add this dependency to `build.sbt`
 ```sbt
-  "org.vastblue" % "unifile_3" % "0.3.12"
+  "org.vastblue" % "unifile_3" % "0.4.1"
 For `scala 3.5+` or `scala-cli` scripts:
-  "//> using dep org.vastblue:unifile_3:0.3.12"
+  "//> using dep org.vastblue:unifile_3:0.4.1"
 
 ## TL;DR
 Simplicity and Universal Portability:
@@ -83,7 +83,7 @@ The following example might surprise Windows developers, since JVM languages don
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 
 import vastblue.unifile.*
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ javacOptions ++= Seq("-source", "17", "-target", "17")
 //ThisBuild / envFileName   := "dev.env" // sbt-dotenv plugin gets build environment here
 ThisBuild / scalaVersion  := scalaVer
 
-ThisBuild / version       := "0.3.12"
+ThisBuild / version       := "0.4.1"
 ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / organization         := "org.vastblue"

--- a/jsrc/bashPath.sc
+++ b/jsrc/bashPath.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 
 import vastblue.unifile.*
 

--- a/jsrc/bashPathCli.sc
+++ b/jsrc/bashPathCli.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 
 import vastblue.unifile.*
 

--- a/jsrc/cmdInfo.sc
+++ b/jsrc/cmdInfo.sc
@@ -1,14 +1,11 @@
-#!/usr/bin/env -S scalaQ
-//#!/usr/bin/env -S scala-cli shebang
+#!/usr/bin/env -S scala
 //package vastblue.demo
 
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 import vastblue.unifile.*
 
-//CmdInfo.main(args)
 object CmdInfo {
   def main(args: Array[String]): Unit = {
-
     printf("[%s]\n", unifile.Info.scalaRuntimeVersion)
     printf("# args [%s]\n", args.toSeq.mkString("|"))
     for ((arg, i) <- args.zipWithIndex) {

--- a/jsrc/fstabCli.sc
+++ b/jsrc/fstabCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 
 // display native path and lines.size of /etc/fstab
 // format: off

--- a/jsrc/listLoadedClasses.sc
+++ b/jsrc/listLoadedClasses.sc
@@ -1,0 +1,72 @@
+#!/usr/bin/env -S scala-cli shebang
+//package vast.apps
+
+//> using jvm 17
+//> using scala 3.6.4
+//> using dep org.vastblue::unifile:0.4.1
+
+import vastblue.unifile.*
+
+object ListLoadedClasses {
+  private def verby: Boolean = {
+    def verbyVar: String = Option(System.getenv("SCRIPT_VERBY")).getOrElse("")
+    verbyVar.nonEmpty
+  }
+
+  val isWindows: Boolean = System.getProperty("os.name").toLowerCase.contains("win")
+
+  import scala.jdk.CollectionConverters.*
+  lazy val classNames: Set[String] = Thread.getAllStackTraces.keySet().asScala
+    .flatMap(_.getStackTrace.map(_.getClassName))
+    .toSet
+
+  def stackHeadFilename: String = new Exception().getStackTrace.head.getFileName
+
+  lazy val scalaCliScript = {
+    stackHeadFilename match {
+    case s if s.nonEmpty =>
+      s
+    case _ =>
+      classNames.find { _.endsWith("$_") } match {
+      case Some(name) =>
+        // not always correct w.r.t. extension
+        s"${name.reverse.drop(2).reverse}.sc"
+      case None =>
+        classNames.find { _.endsWith("_sc") } match {
+        case Some(name) =>
+          // not always correct w.r.t. extension
+          s"${name.replaceFirst("_sc$", ".sc")}"
+        case None =>
+          ""
+        }
+      }
+    }
+  }
+
+  def scalaCliScriptPath: String = {
+    import java.nio.file.Files
+    if (scalaCliScript.nonEmpty) {
+      if (java.nio.file.Files.isRegularFile(Paths.get(scalaCliScript))) {
+        scalaCliScript
+      } else {
+        where(scalaCliScript)
+      }
+    } else {
+      Option(sys.props("script.path")).getOrElse("")
+    }
+  }
+
+  private lazy val finder = if (isWindows) "where.exe" else "which"
+  def where(progname: String): String = {
+    import scala.sys.process.*
+    val cliScriptPath = Seq(finder, scalaCliScript).lazyLines_!.take(1).filter { (s: String) => s.trim.nonEmpty }.mkString.replace('\\', '/')
+    if (verby) System.err.printf("cliScriptPath[%s]\n", cliScriptPath)
+    cliScriptPath
+  }
+
+  def main(args: Array[String]): Unit = {
+    printf("scalaCliScript: [%s]\n", scalaCliScript)
+    printf("scalaCliScript: [%s]\n", scalaCliScript)
+    printf("scalaCliScriptPath: [%s]\n", scalaCliScriptPath)
+  }
+}

--- a/jsrc/palletRef.sc
+++ b/jsrc/palletRef.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 
 import vastblue.unifile.*
 

--- a/jsrc/palletRefCli.sc
+++ b/jsrc/palletRefCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 
 import vastblue.unifile.*
 

--- a/jsrc/sbt2cs.sc
+++ b/jsrc/sbt2cs.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang
 
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 import vastblue.unifile.*
 
 /*
@@ -11,7 +11,7 @@ import vastblue.unifile.*
  * Example conversion from sbt dependency format to scala-cli lib format:
  *
  * from:
- *   org.vastblue             %% unifile       % 0.3.12
+ *   org.vastblue             %% unifile       % 0.4.1
  *   org.vastblue             %% pallet        % 0.10.21
  *   org.scalanlp             %% breeze-viz    % 2.1.0
  *   org.scalanlp             %% breeze        % 2.1.0
@@ -23,7 +23,7 @@ import vastblue.unifile.*
  *   com.github.darrenjw      %% scala-glm     % 0.8
  *
  * to:
- *   //> using dep "org.vastblue::unifile:0.3.12"
+ *   //> using dep "org.vastblue::unifile:0.4.1"
  *   //> using dep "org.vastblue::pallet::0.10.21"
  *   //> using dep "org.scalanlp::breeze-viz::2.1.0"
  *   //> using dep "org.scalanlp::breeze::2.1.0"
@@ -86,7 +86,7 @@ com.github.fommil.netlib % all            % 1.1.2
 com.github.darrenjw      %% scala-glm     % 0.8
 org.scala-lang.modules   %% scala-swing   % 3.0.0
 net.ruippeixotog         %% scala-scraper % 3.1.1
-org.vastblue             %% unifile       % 0.3.12
+org.vastblue             %% unifile       % 0.4.1
 org.vastblue             %% pallet        % 0.10.21
 """.trim.split("[\r\n]+").toList.filter { _.nonEmpty }
 

--- a/jsrc/sbt2csCli.sc
+++ b/jsrc/sbt2csCli.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang
 
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 import vastblue.unifile.*
 
 /*
@@ -11,7 +11,7 @@ import vastblue.unifile.*
  * Example conversion from sbt dependency format to scala-cli lib format:
  *
  * from:
- *   org.vastblue             %% unifile       % 0.3.12
+ *   org.vastblue             %% unifile       % 0.4.1
  *   org.vastblue             %% pallet        % 0.10.21
  *   org.scalanlp             %% breeze-viz    % 2.1.0
  *   org.scalanlp             %% breeze        % 2.1.0
@@ -23,7 +23,7 @@ import vastblue.unifile.*
  *   com.github.darrenjw      %% scala-glm     % 0.8
  *
  * to:
- *   //> using dep "org.vastblue::unifile:0.3.12"
+ *   //> using dep "org.vastblue::unifile:0.4.1"
  *   //> using dep "org.vastblue::pallet::0.10.21"
  *   //> using dep "org.scalanlp::breeze-viz::2.1.0"
  *   //> using dep "org.scalanlp::breeze::2.1.0"
@@ -86,7 +86,7 @@ com.github.fommil.netlib % all            % 1.1.2
 com.github.darrenjw      %% scala-glm     % 0.8
 org.scala-lang.modules   %% scala-swing   % 3.0.0
 net.ruippeixotog         %% scala-scraper % 3.1.1
-org.vastblue             %% unifile       % 0.3.12
+org.vastblue             %% unifile       % 0.4.1
 org.vastblue             %% pallet        % 0.10.21
 """.trim.split("[\r\n]+").toList.filter { _.nonEmpty }
 

--- a/jsrc/scriptname.sc
+++ b/jsrc/scriptname.sc
@@ -1,0 +1,27 @@
+#!/usr/bin/env -S scala-cli shebang
+//#!/usr/bin/env -S scalaQ
+
+//> using dep org.vastblue::unifile:0.4.1
+
+import vastblue.Script.* // guessMainClass
+
+// guess name of script by examining live stack trace at runtime
+object Scriptname {
+  def sunJavaCommand = sys.props("sun.java.command")
+  def main(args: Array[String]): Unit =
+    val stackHeadFilename: String = new Exception().getStackTrace.head.getFileName
+    printf("stackHeadFilename[%s]\n", stackHeadFilename)
+    printf("mainProgramPath[%s]\n", mainProgramPath)
+    printf("guessMainClass[%s]\n", guessMainClass)
+    printf("sunJavaCommand[%s]\n", sunJavaCommand)
+    val program = stackHeadFilename.trim match {
+    case "" => guessMainClass
+    case str => str
+    }
+    printf("[%s]\n", program)
+    sys.props.foreach { s =>
+      if (s.toString.contains(program)){
+        printf("%s\n", s)
+      }
+    }
+}

--- a/jsrc/unameGreeting.sc
+++ b/jsrc/unameGreeting.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S scala-cli shebang
 
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 import vastblue.unifile.*
 
 printf("uname / osType / osName:\n%s\n", s"platform info: ${unameShort} / ${osType} / ${osName}")

--- a/jsrc/unameGreetingCli.sc
+++ b/jsrc/unameGreetingCli.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 
 import vastblue.unifile.*
 

--- a/src/main/scala/vastblue/MainArgs.scala
+++ b/src/main/scala/vastblue/MainArgs.scala
@@ -39,8 +39,8 @@ object MainArgs {
       printf("_args [%s]\n", _args.mkString("|"))
       // new Exception().printStackTrace()
     }
-    val e: StackTraceElement = Script._scriptProp
-    val argv                 = (e.filePath :: _args.toList).toArray.toSeq
+    val filePath: String = Script.guessMainClass
+    val argv             = (filePath :: _args.toList).toArray.toSeq
     val validArgs = if (!isWindows || shell.isEmpty) {
       argv
     } else {
@@ -90,8 +90,7 @@ object MainArgs {
   }
 
   private val scriptArgz: Seq[String] = {
-    val e: StackTraceElement = scriptProp(new Exception)
-    val sprop                = e.filePath
+    val sprop: String = Script.guessMainClass
     val sjc: Array[String]   = sunJavaCommand.split(" ")
     var argz: Array[String] = {
       val list = sjc.dropWhile { (s: String) =>
@@ -212,7 +211,7 @@ object MainArgs {
     }
     val scriptArgs: Seq[String] = {
       import vastblue.Script.*
-      val scrpath: String       = Script._scriptProp.filePath
+      val scrpath: String       = Script.guessMainClass
       def notScriptPath         = (s: String) => !s.endsWith(scrpath) && !validScriptOrClassName(s)
       val rawtail: List[String] = rawargv.dropWhile(notScriptPath(_)).toList
       (scrpath :: rawtail.drop(1)).toIndexedSeq

--- a/src/main/scala/vastblue/Script.scala
+++ b/src/main/scala/vastblue/Script.scala
@@ -7,34 +7,82 @@ import java.nio.file.Path
 import vastblue.util.PathExtensions.*
 
 object Script {
-  private lazy val verby: String = Option(System.getenv("SCRIPT_VERBY")).getOrElse("")
-  private def verbyFlag          = verby.nonEmpty
+  private def verby: Boolean = {
+    def verbyVar: String = Option(System.getenv("SCRIPT_VERBY")).getOrElse("")
+    verbyVar.nonEmpty
+  }
 
-  def searchStackTrace(e: Exception = new Exception()): StackTraceElement = {
-    val stackList: List[StackTraceElement] = e.getStackTrace.toList
-    val relevant: StackTraceElement = stackList.dropWhile((e: StackTraceElement) =>
-      val s = e.toString
-      s.contains("unifile.") ||
-      s.contains("vastblue.Script.scala") ||
-      s.contains("vastblue.ArgsUtil.scala") ||
-      s.contains("vastblue.MainArgs") ||
-      s.contains("vastblue.util.") ||
-      s.contains("scalatest") ||
-      s.contains("junit")
-    ).take(1) match {
-    case Nil =>
-      stackList.last
-    case head :: tail =>
-      head
+  import scala.jdk.CollectionConverters.*
+  def classNames: Set[String] = Thread.getAllStackTraces.keySet().asScala
+    .flatMap(_.getStackTrace.map(_.getClassName))
+    .toSet
+
+  lazy val scalaCliScript = {
+    classNames.find { _.endsWith("$_") } match {
+    case Some(name) =>
+      // not always correct w.r.t. extension
+      s"${name.reverse.drop(2).reverse}.sc"
+    case None =>
+      classNames.find { _.endsWith("_sc") } match {
+      case Some(name) =>
+        // not always correct w.r.t. extension
+        s"${name.replaceFirst("_sc$", ".sc")}"
+      case None =>
+        Option(sys.props("script.path")).getOrElse("")
+      }
     }
-    relevant
+  }
+
+  def mainProgramPath: String = {
+    if (scalaCliScript.nonEmpty) {
+      if (java.nio.file.Files.isRegularFile(Paths.get(scalaCliScript))) {
+        scalaCliScript
+      } else {
+        val scrip = where(scalaCliScript)
+        scrip
+      }
+    } else {
+      Option(sys.props("script.path")).getOrElse("")
+    }
+  }
+
+  private val isWindows: Boolean = System.getProperty("os.name").toLowerCase.contains("win")
+  private lazy val finder = if (isWindows) "where.exe" else "which"
+  private def where(progname: String): String = {
+    import scala.sys.process.*
+    var (stdout, stderr) = (Vector.empty[String], Vector.empty[String])
+    val cmd = Seq(finder, scalaCliScript)
+    val status = cmd ! ProcessLogger(stdout :+= _.trim, stderr :+= _.trim)
+    val cliScriptPath = stdout.take(1).mkString.trim.replace('\\', '/') match {
+      case "" => progname
+      case str => str
+    }
+    cliScriptPath
+  }
+
+  private val propsScriptPath = _propOrElse("script.path", "")
+
+  // produce `scriptPath` or equivalent in various contexts:
+  //    scala-cli script
+  //    legacy scriptQ
+  //    IDE debugger session
+  def guessMainClass: String = {
+    if (mainProgramPath.nonEmpty) {
+      mainProgramPath
+    } else if (propsScriptPath.nonEmpty){
+      propsScriptPath
+    } else if (mainFromStack.nonEmpty) {
+      mainFromStack
+    } else {
+      "unknownMainClass"
+    }
   }
 
   def scriptNameSources = Seq(
     _propOrElse("script.path", mainFromStack),
-    Script.searchStackTrace(new Exception()),
+    scalaCliScript
   )
-  def mainFromStack: String = {
+  private def mainFromStack: String = {
     // might return empty string?
     val result = new java.io.StringWriter()
     new RuntimeException("stack").printStackTrace(new java.io.PrintWriter(result))
@@ -49,33 +97,15 @@ object Script {
     e.getClassName
   }
 
-//  def stackFilePath(e: StackTraceElement): String = {
-//    e.filePath
-//  }
   def _scriptPath: String = {
-    val scriptPath = sys.props("script.path")
-    if (Option(scriptPath).nonEmpty) {
-      scriptPath
-    } else {
-      _scriptProp.filePath
-    }
+    guessMainClass
   }
   def scriptName: String = _scriptPath match {
   case "" | "MainArgs.scala" | "mainargs.scala" | "Script.scala" =>
-    scriptProp().filePath.posx
+    guessMainClass.path.posx
   case name =>
     name.posx
   }
-  extension (e: StackTraceElement) {
-    def filePath: String = {
-      val fname      = e.getFileName
-      val class2path = e.getClassName.replace('.', '/')
-      class2path.replaceFirst("[^/]*$", fname)
-    }
-  }
-  def _scriptProp: StackTraceElement = Script.searchStackTrace(new Exception())
-  def stackElementFilePath: String   = _scriptProp.filePath
-  def stackElementClassName: String  = _scriptProp.getClassName
 
   // TODO: this works if running from a script, but need to gracefully do something
   // otherwise.  If executing from a jar file, read manifest to get main class

--- a/src/main/scala/vastblue/demo/BashPath.scala
+++ b/src/main/scala/vastblue/demo/BashPath.scala
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 
 import vastblue.unifile.*
 

--- a/src/main/scala/vastblue/demo/CmdInfo.scala
+++ b/src/main/scala/vastblue/demo/CmdInfo.scala
@@ -1,10 +1,12 @@
-//#!/usr/bin/env -S scala
+//#!/usr/bin/env -S scala-cli shebang
 package vastblue.demo
 
+//> using dep "org.vastblue::unifile:0.4.1"
 import vastblue.unifile.*
 
 object CmdInfo {
   def main(args: Array[String]): Unit = {
+    printf("[%s]\n", unifile.Info.scalaRuntimeVersion)
     printf("# args [%s]\n", args.toSeq.mkString("|"))
     for ((arg, i) <- args.zipWithIndex) {
       printf("A:  args(%d) == [%s]\n", i, arg)

--- a/src/main/scala/vastblue/demo/PalletRef.scala
+++ b/src/main/scala/vastblue/demo/PalletRef.scala
@@ -2,7 +2,7 @@
 package vastblue.demo
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 
 import vastblue.unifile.*
 

--- a/src/main/scala/vastblue/demo/UnameGreeting.scala
+++ b/src/main/scala/vastblue/demo/UnameGreeting.scala
@@ -1,7 +1,7 @@
 //#!/usr/bin/env -S scala
 package vastblue.demo
 
-//> using dep "org.vastblue::unifile:0.3.12"
+//> using dep "org.vastblue::unifile:0.4.1"
 import vastblue.unifile.*
 
 object UnameGreeting {

--- a/src/main/scala/vastblue/util/PathExtensions.scala
+++ b/src/main/scala/vastblue/util/PathExtensions.scala
@@ -130,7 +130,7 @@ trait PathExtensions {
 
   def showLimitedStack(e: Throwable = Util.newEx): Unit = vastblue.file.Util._showLimitedStack(e)
 
-  def scriptProp(e: Exception = new Exception()): StackTraceElement = Script.searchStackTrace(e)
+  //def scriptProp(e: Exception = new Exception()): StackTraceElement = Script.searchStackTrace(e)
 
 //  def prepArgs(args: Seq[String]) = Script.prepArgs(args)
 


### PR DESCRIPTION
Updated `Script.scriptName` to correctly provide a meaningful program name in different contexts:

- `scala-cli` scripts get the name from a compile-time synthesized variable named `scriptPath`
- legacy `sys.props("script.path")` when running scala versions prior to 3.5

It's not possible to access the synthesized `scriptPath` provided by `scala-cli` compiler here, but a reasonable guess can be reconstructed from classnames on the stack.

Updated example sources and README.md examples to reflect new release version.